### PR TITLE
added 'name' attribute to metadata.rb for chef 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 gemfile:
   - test/support/Gemfile
 rvm:
-  - 1.9.3
+  - 2.0.0
 script: BUNDLE_GEMFILE=test/support/Gemfile bundle exec rake test foodcritic

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             'multipath'
 maintainer       "Eric G. Wolfe"
 maintainer_email "wolfe21@marshall.edu"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs and configures device-mapper-multipath"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 recommends       "iscsi"
 recommends       "dbench"
-version          "0.0.8"
+version          "0.0.9"
 
 %w{ redhat centos scientific amazon oracle }.each do |os|
   supports os, ">= 5.0"


### PR DESCRIPTION
chef 12.3 client is complaining about the lack of a 'name' attribute in metadata.rb
